### PR TITLE
Dev

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,9 +18,30 @@ minetest.log(S("[MOD] lib_trm:  Loading..."))
 minetest.log(S("[MOD] lib_trm:  Legal Info: Copyright " .. lib_trm.copyright .. " " ..lib_trm.authorship))
 minetest.log(S("[MOD] lib_trm:  License: " .. lib_trm.license))
 
+	
+	dofile(lib_trm.path_mod.."/lib_trm_toolcap_modifier.lua")
+	dofile(lib_trm.path_mod.."/lib_trm_tool_ranks.lua")
+	
+	
+	--minetest.register_on_mods_loaded(
+	--	if minetest.global_exists("default") and minetest.get_modpath("default") then
+	--		dofile(MP.."/lib_trm_default_support.lua")
+	--	end
+	--)
 
-dofile(lib_trm.path_mod.."/lib_trm_toolcap_modifier.lua")
-dofile(lib_trm.path_mod.."/lib_trm_tool_ranks.lua")
+	minetest.register_on_mods_loaded(function()
+		for _, node_name in pairs(minetest.registered_nodes) do
+			local node_def = minetest.registered_nodes[node_name]
+			if node_def.tool_capabilities then
+				minetest.override_item(node_name, {
+					original_description = "Diamond Pickaxe",
+					description = toolranks.create_description("Diamond Pickaxe", 0, 1),
+					after_use = toolranks.new_afteruse
+				})
+			end
+		end
+	end
+
 
 
 minetest.log(S("[MOD] lib_trm:  Successfully loaded."))

--- a/init.lua
+++ b/init.lua
@@ -14,34 +14,36 @@ lib_trm.path_world = minetest.get_worldpath()
 lib_trm.intllib = minetest.get_translator(lib_trm.name)
 local S = lib_trm.intllib
 
-minetest.log(S("[MOD] lib_trm:  Loading..."))
-minetest.log(S("[MOD] lib_trm:  Legal Info: Copyright " .. lib_trm.copyright .. " " ..lib_trm.authorship))
-minetest.log(S("[MOD] lib_trm:  License: " .. lib_trm.license))
+--minetest.log(S("[MOD] lib_trm:  Loading..."))
+--minetest.log(S("[MOD] lib_trm:  Legal Info: Copyright " .. lib_trm.copyright .. " " ..lib_trm.authorship .. ""))
+--minetest.log(S("[MOD] lib_trm:  License: " .. lib_trm.license .. ""))
+
+minetest.log("[MOD] lib_trm:  Loading...")
+minetest.log("[MOD] lib_trm:  Legal Info: Copyright " .. lib_trm.copyright .. " " ..lib_trm.authorship .. "")
+minetest.log("[MOD] lib_trm:  License: " .. lib_trm.license .. "")
 
 	
 	dofile(lib_trm.path_mod.."/lib_trm_toolcap_modifier.lua")
 	dofile(lib_trm.path_mod.."/lib_trm_tool_ranks.lua")
 	
 	
-	--minetest.register_on_mods_loaded(
-	--	if minetest.global_exists("default") and minetest.get_modpath("default") then
-	--		dofile(MP.."/lib_trm_default_support.lua")
-	--	end
-	--)
 
 	minetest.register_on_mods_loaded(function()
-		for _, node_name in pairs(minetest.registered_nodes) do
-			local node_def = minetest.registered_nodes[node_name]
-			local node_desc = node_def.description
-			if node_def.tool_capabilities then
-				minetest.override_item(node_name, {
-					original_description = node_desc,
-					description = toolranks.create_description(node_desc, 0, 1),
-					after_use = toolranks.new_afteruse
-				})
+		for node_name, node_def in pairs(minetest.registered_tools) do
+			if node_name and node_name ~= "" then
+				if node_def then
+					if not node_def.original_description then
+						local node_desc = node_def.description
+						minetest.override_item(node_name, {
+							original_description = node_desc,
+							description = toolranks.create_description(node_desc, 0, 1),
+							after_use = toolranks.new_afteruse,
+						})
+					end
+				end
 			end
 		end
-	end
+	end)
 
 
 

--- a/init.lua
+++ b/init.lua
@@ -32,10 +32,11 @@ minetest.log(S("[MOD] lib_trm:  License: " .. lib_trm.license))
 	minetest.register_on_mods_loaded(function()
 		for _, node_name in pairs(minetest.registered_nodes) do
 			local node_def = minetest.registered_nodes[node_name]
+			local node_desc = node_def.description
 			if node_def.tool_capabilities then
 				minetest.override_item(node_name, {
-					original_description = "Diamond Pickaxe",
-					description = toolranks.create_description("Diamond Pickaxe", 0, 1),
+					original_description = node_desc,
+					description = toolranks.create_description(node_desc, 0, 1),
 					after_use = toolranks.new_afteruse
 				})
 			end


### PR DESCRIPTION
Update the on_mods_loaded call to correctly use minetest.registered_tools instead of minetest.registered_nodes.

All items registered as tools, armor included, will get ranked and leveled, according to the toolranks code.

All tools that have cracky, choppy, crumbly, or snappy tool_capabilities will further get the c-t-m modifiers applied to them.

This has been tested locally, not using default, farming, or other more common 'tools' registering mods.  This was tested with an unmodified nssm, whose tools were registered with toolranks and c-t-m modifiers working.